### PR TITLE
Fix multiple addresses support

### DIFF
--- a/swede
+++ b/swede
@@ -610,6 +610,8 @@ if __name__ == '__main__':
 						print genTLSA(args.host, args.protocol, args.port, cert, 'rfc', args.usage, args.selector, args.mtype)
 					else:
 						print genTLSA(args.host, args.protocol, args.port, cert, args.output, args.usage, args.selector, args.mtype)
+					# Done here Cleanup for next round
+					cert=None
 
 		else: # Pass the path to the certificate to the genTLSA function
 			if args.output == 'both':


### PR DESCRIPTION
If a domain has multiple addresses reset cert to Null after
first succesfully TLSA generation. Else getHash (as_der) segfaults.

Testcase: swede --insecure create --usage=0 google.com
