### PR TITLE
getRecords should not raise an error when there are no records (e.g. no AAAA)

### DIFF
--- a/swede
+++ b/swede
@@ -146,7 +146,9 @@ def getRecords(hostname, rrtype='A', secure=True):
 		raise Exception('Error: rrtype in wrong format, neither int nor str.')
 
 	status, result = ctx.resolve(hostname, rrtype=rrtype)
-	if status == 0 and result.havedata:
+	if status == 0:
+		if not result.havedata:
+			return []
 		if not result.secure:
 			if secure:
 				# The data is insecure and a secure lookup was requested


### PR DESCRIPTION
Hello,

If the lookup is successful but does not contain data, getRecords raises an error which in turn prevents the code from doing anything (print error and sys.exit).

$ ./swede verify stalkr.net
Received the following record for name _443._tcp.stalkr.net.:
        Usage:                          1 (End-Entity Constraint + chain to CA)
        Selector:                       1 (SubjectPublicKeyInfo)
        Matching Type:                  1 (SHA-256)
        Certificate for Association:    a0e5e59adc9932a4d9977fe37c50da32d12119fe1478ffca89620bfa3206b750
This record is valid (well-formed).
Attempting to verify the record with the TLS service...
Unable to resolve stalkr.net.: Unsuccesful lookup or no data returned for rrtype 28.

rrtype 28 is AAAA and indeed there is no AAAA for stalkr.net:
$ host -t AAAA stalkr.net
stalkr.net has no AAAA record

The proposed change returns an empty list when the lookup is successful but there is no record:
$ ./swede verify stalkr.net
Received the following record for name _443._tcp.stalkr.net.:
        Usage:                          1 (End-Entity Constraint + chain to CA)
        Selector:                       1 (SubjectPublicKeyInfo)
        Matching Type:                  1 (SHA-256)
        Certificate for Association:    a0e5e59adc9932a4d9977fe37c50da32d12119fe1478ffca89620bfa3206b750
This record is valid (well-formed).
Attempting to verify the record with the TLS service...
Got the following IP: 91.121.51.205
[...]

Cheers,
StalkR
