### PR TITLE
Fix --output=both to show both, generic and RFC stype, instead of two RFC style outputs

### DIFF
--- a/swede
+++ b/swede
@@ -692,7 +692,7 @@ if __name__ == '__main__':
 
 				if cert: # Print the requested records based on the retrieved certificates
 					if args.output == 'both':
-						print genTLSA(args.host, args.protocol, args.port, cert, 'draft', args.usage, args.selector, args.mtype)
+						print genTLSA(args.host, args.protocol, args.port, cert, 'generic', args.usage, args.selector, args.mtype)
 						print genTLSA(args.host, args.protocol, args.port, cert, 'rfc', args.usage, args.selector, args.mtype)
 					else:
 						print genTLSA(args.host, args.protocol, args.port, cert, args.output, args.usage, args.selector, args.mtype)
@@ -706,7 +706,7 @@ if __name__ == '__main__':
 
 		else: # Pass the path to the certificate to the genTLSA function
 			if args.output == 'both':
-				print genTLSA(args.host, args.protocol, args.port, args.certificate, 'draft', args.usage, args.selector, args.mtype)
+				print genTLSA(args.host, args.protocol, args.port, args.certificate, 'generic', args.usage, args.selector, args.mtype)
 				print genTLSA(args.host, args.protocol, args.port, args.certificate, 'rfc', args.usage, args.selector, args.mtype)
 			else:
 				print genTLSA(args.host, args.protocol, args.port, args.certificate, args.output, args.usage, args.selector, args.mtype)


### PR DESCRIPTION
minor bug fix
